### PR TITLE
Add sensor simulations for Eddiebot base

### DIFF
--- a/eddiebot_description/robots/eddie_kinect_v1/eddiebot.urdf.xacro
+++ b/eddiebot_description/robots/eddie_kinect_v1/eddiebot.urdf.xacro
@@ -5,6 +5,8 @@
   <xacro:include filename="$(find eddiebot_description)/urdf/stacks/circle_stack.urdf.xacro"/>
   <xacro:include filename="$(find eddiebot_description)/urdf/stacks/camera_stand.urdf.xacro"/>
   <xacro:include filename="$(find eddiebot_description)/urdf/sensors/kinect_v1.urdf.xacro"/>
+  <!-- smh   -->
+  <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ultrasonic_sensor.urdf.xacro"/>
 
   <!-- eddiebot -->
   <xacro:create_base/>

--- a/eddiebot_description/urdf/sensors/ir_sensor.urdf.xacro
+++ b/eddiebot_description/urdf/sensors/ir_sensor.urdf.xacro
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<robot name="ir_sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+    
+    <xacro:property name="length" value="0.01"/>
+    <xacro:property name="width" value="0.06" />
+    <xacro:property name="height" value="0.03" />
+
+    <xacro:macro name="ir_sensor_sim" params="name parent topic x y z roll pitch yaw linkname jointname">
+
+         <link name="${linkname}">
+            <xacro:inertial_cuboid mass="1" x="${length}" y="${width}" z="${height}"/>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${length} ${width} ${height}" />
+                </geometry>
+                <material name ="material_black" />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${length} ${width} ${height}" />
+                </geometry>
+            </collision>
+        </link>
+
+        <joint name="${jointname}" type="fixed">
+            <origin xyz="${x} ${y} ${z}" rpy="${roll} ${pitch} ${yaw}" />
+            <parent link="${parent}" />
+            <child link="${linkname}" />
+        </joint>        
+
+ 
+        <gazebo reference="${linkname}">
+            
+            <sensor name='${name}' type='gpu_lidar'>"
+                <always_on>1</always_on>
+                <update_rate>5</update_rate>
+                <visualize>1</visualize>
+                <topic>${topic}</topic>
+                <ray>
+                    <scan>
+                        <horizontal>
+                            <samples>1</samples>
+                            <resolution>1</resolution>
+                            <min_angle>0</min_angle>
+                            <max_angle>0</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>0.1</min>
+                        <max>0.8</max>
+                        <resolution>0.02</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.1</mean>
+                        <stddev>0.005</stddev>
+                    </noise>
+                </ray>
+            </sensor>
+        </gazebo>
+    </xacro:macro>
+</robot>

--- a/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
+++ b/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <robot name="ultrasonic_sensor" xmlns:xacro="http://ros.org/wiki/xacro">
     
-    <xacro:property name="length" value="0.06"/>
-    <xacro:property name="width" value="0.01" />
+    <xacro:property name="length" value="0.01"/>
+    <xacro:property name="width" value="0.06" />
     <xacro:property name="height" value="0.03" />
 
     <xacro:macro name="ultrasonic_sensor_sim" params="name parent topic x y z roll pitch yaw linkname jointname">

--- a/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
+++ b/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<robot name="ultrasonic_sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+    
+    <xacro:property name="length" value="0.06"/>
+    <xacro:property name="width" value="0.01" />
+    <xacro:property name="height" value="0.03" />
+
+    <xacro:macro name="ultrasonic_sensor_sim" params="name parent topic x y z roll pitch yaw linkname jointname">
+
+         <link name="${linkname}">
+            <xacro:inertial_cuboid mass="1" x="${length}" y="${width}" z="${height}"/>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${length} ${width} ${height}" />
+                </geometry>
+                <material name ="black" />
+            </visual>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${length} ${width} ${height}" />
+                </geometry>
+            </collision>
+        </link>
+
+        <joint name="${jointname}" type="fixed">
+            <origin xyz="${x} ${y} ${z}" rpy="${roll} ${pitch} ${yaw}" />
+            <parent link="${parent}" />
+            <child link="${linkname}" />
+        </joint>        
+
+ 
+        <gazebo reference="${linkname}">
+            <sensor name="${name}" type="gpu_lidar">
+                <always_on>1</always_on>
+                <update_rate>5</update_rate>
+                <visualize>1</visualize>
+                <topic>${topic}</topic>
+                <!-- <topic>smh</topic> -->
+                <ray>
+                    <scan>
+                        <horizontal>
+                            <samples>640</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-1.396263</min_angle>
+                            <max_angle>1.396263</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>0.08</min>
+                        <max>4</max>
+                        <resolution>0.02</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.1</mean>
+                        <stddev>0.005</stddev>
+                    </noise>
+                </ray>
+            </sensor>
+        </gazebo>
+    </xacro:macro>
+</robot>

--- a/eddiebot_description/urdf/stacks/create_base.urdf.xacro
+++ b/eddiebot_description/urdf/stacks/create_base.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:include filename="$(find eddiebot_description)/urdf/common.urdf.xacro"/>
 
   <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ultrasonic_sensor.urdf.xacro"/>
+  <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ir_sensor.urdf.xacro"/>
 
   <!-- Define robot constants -->
   <xacro:property name="base_length" value="0.0095"/>
@@ -260,9 +261,13 @@
       </plugin>
     </gazebo>
 
-    <xacro:ultrasonic_sensor_sim name="ultrasonic_l" parent="base_link" topic="ultrasonic_l" x="0.2" y="0.08" z="0.028" roll="0.000" pitch="0.000" yaw="20" linkname="ultrasonic_link_l" jointname="ultrasonic_joint_l"/>
-    <xacro:ultrasonic_sensor_sim name="ultrasonic_r" parent="base_link" topic="ultrasonic_r" x="0.2" y="-0.08" z="0.028" roll="0.000" pitch="0.000" yaw="-20" linkname="ultrasonic_link_r" jointname="ultrasonic_joint_r"/>
+    <xacro:ultrasonic_sensor_sim name="ultrasonic_l" parent="base_link" topic="ultrasonic_l" x="0.2" y="0.08" z="0.028" roll="0.0" pitch="0.0" yaw="0.38" linkname="ultrasonic_link_l" jointname="ultrasonic_joint_l"/>
+    <xacro:ultrasonic_sensor_sim name="ultrasonic_r" parent="base_link" topic="ultrasonic_r" x="0.2" y="-0.08" z="0.028" roll="0.0" pitch="0.0" yaw="-0.38" linkname="ultrasonic_link_r" jointname="ultrasonic_joint_r"/>
 
+    <xacro:ir_sensor_sim name="ir_f" parent="base_link" topic="ir_f" x="0.2" y="0.0" z="0.028" roll="0.0" pitch="0.0" yaw="0.0" linkname="ir_link_f" jointname="ir_joint_f"/>
+    <xacro:ir_sensor_sim name="ir_l" parent="base_link" topic="ir_l" x="0.15" y="0.12" z="0.028" roll="0.0" pitch="0.0" yaw="0.47" linkname="ir_link_l" jointname="ir_joint_l"/>
+    <xacro:ir_sensor_sim name="ir_r" parent="base_link" topic="ir_r" x="0.15" y="-0.12" z="0.028" roll="0.0" pitch="0.0" yaw="-0.47" linkname="ir_link_r" jointname="ir_joint_r"/>
+ 
   </xacro:macro>
 
 </robot>

--- a/eddiebot_description/urdf/stacks/create_base.urdf.xacro
+++ b/eddiebot_description/urdf/stacks/create_base.urdf.xacro
@@ -3,6 +3,8 @@
 
   <xacro:include filename="$(find eddiebot_description)/urdf/common.urdf.xacro"/>
 
+  <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ultrasonic_sensor.urdf.xacro"/>
+
   <!-- Define robot constants -->
   <xacro:property name="base_length" value="0.0095"/>
   <xacro:property name="base_radius" value="0.2245"/>
@@ -257,6 +259,9 @@
         <topic>model/eddiebot/joint_states</topic>
       </plugin>
     </gazebo>
+
+    <xacro:ultrasonic_sensor_sim name="ultrasonic_l" parent="base_link" topic="ultrasonic_l" x="0.2" y="0.08" z="0.028" roll="0.000" pitch="0.000" yaw="20" linkname="ultrasonic_link_l" jointname="ultrasonic_joint_l"/>
+    <xacro:ultrasonic_sensor_sim name="ultrasonic_r" parent="base_link" topic="ultrasonic_r" x="0.2" y="-0.08" z="0.028" roll="0.000" pitch="0.000" yaw="-20" linkname="ultrasonic_link_r" jointname="ultrasonic_joint_r"/>
 
   </xacro:macro>
 

--- a/eddiebot_gazebo/worlds/maze_marked.sdf
+++ b/eddiebot_gazebo/worlds/maze_marked.sdf
@@ -9,6 +9,7 @@
     <plugin name='ignition::gazebo::systems::UserCommands' filename='ignition-gazebo-user-commands-system'/>
     <plugin name='ignition::gazebo::systems::SceneBroadcaster' filename='ignition-gazebo-scene-broadcaster-system'/>
     <plugin name='ignition::gazebo::systems::Contact' filename='ignition-gazebo-contact-system'/>
+
     <gravity>0 0 -9.8000000000000007</gravity>
     <magnetic_field>6.0000000000000002e-06 2.3e-05 -4.1999999999999998e-05</magnetic_field>
     <atmosphere type='adiabatic'/>


### PR DESCRIPTION
This pull request introduces sensor simulations for the Eddiebot base in the robot description. The goal is to enhance the robot model by accurately simulating ultrasonic and IR sensors. The following changes have been made:

1. Added ultrasonic sensor simulations for the left and right sensors on the Eddiebot base. These simulations utilize the "ultrasonic_sensor_sim" macro, which includes the necessary elements such as the link, joint, and gazebo sensor. The sensor parameters are configured to simulate a GPU lidar sensor with specific properties for scan, range, and noise.

2. Added IR sensor simulations for the front, left, and right sensors on the Eddiebot base. These simulations utilize the "ir_sensor_sim" macro, which includes the required elements such as the link, joint, and gazebo sensor. Similar to the ultrasonic sensors, the IR sensor parameters are set to simulate a GPU lidar sensor with specific properties for scan, range, and noise.

3. Configured the sensor positions and orientations relative to the base link to ensure accurate simulation. This ensures that the sensors are correctly positioned and aligned with the robot's physical structure.

By adding these sensor simulations, the Eddiebot base can now accurately simulate ultrasonic and IR sensors. This pull request aims to improve the overall functionality and realism of the robot model.