### PR TITLE
Adding ultrasonic and ir sensors.

### DIFF
--- a/eddiebot_description/urdf/sensors/ir_sensor.urdf.xacro
+++ b/eddiebot_description/urdf/sensors/ir_sensor.urdf.xacro
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<robot name="ultrasonic_sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:property name="myx" value="0.055"/>
+    <xacro:property name="myy" value="0.055" />
+    <xacro:property name="myz" value="0.055" />
+                <!-- <xacro:inertial_cuboid mass="1" x="0.1778" y="0.3366" z="0.0762"/> -->
+
+    <xacro:macro name="ir_sensor_sim" params="topic name parent linkname jointname x y z roll pitch yaw">
+        <link name="${linkname}">
+            <xacro:inertial_cuboid mass="1" x="${myx}" y="${myy}" z="${myz}"/>
+            <visual>
+                <!-- <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/> -->
+                <geometry>
+                    <box size="${myx} ${myy} ${myz}" />
+                </geometry>
+                <material name ="material_darkgray" />
+            </visual>
+            <collision>
+                <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${myx} ${myy} ${myz}" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${jointname}" type="fixed">
+            <origin xyz="${x} ${y} ${z}" rpy="${roll} ${pitch} ${yaw}" />
+            <parent link="${parent}" />
+            <child link="${linkname}" />
+        </joint>   
+
+        <gazebo reference="${linkname}">
+            <sensor name="${name}" type="gpu_lidar">
+                <always_on>1</always_on>
+                <update_rate>5</update_rate>
+                <visualize>1</visualize>
+                <topic>${topic}</topic>
+                <ray>
+                    <scan>
+                        <horizontal>
+                            <samples>1</samples>
+                            <resolution>1</resolution>
+                            <min_angle>0</min_angle>
+                            <max_angle>0</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>0.1</min>
+                        <max>0.8</max>
+                        <resolution>0.02</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.1</mean>
+                        <stddev>0.005</stddev>
+                    </noise>
+                </ray>
+            </sensor>
+        </gazebo>     
+    </xacro:macro>
+</robot>

--- a/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
+++ b/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<robot name="ultrasonic_sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+    <xacro:property name="myx" value="0.055"/>
+    <xacro:property name="myy" value="0.055" />
+    <xacro:property name="myz" value="0.055" />
+                <!-- <xacro:inertial_cuboid mass="1" x="0.1778" y="0.3366" z="0.0762"/> -->
+
+    <xacro:macro name="ultrasonic_sensor_sim" params="topic name parent linkname jointname x y z roll pitch yaw">
+        <link name="${linkname}">
+            <xacro:inertial_cuboid mass="1" x="${myx}" y="${myy}" z="${myz}"/>
+            <visual>
+                <!-- <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/> -->
+                <geometry>
+                    <box size="${myx} ${myy} ${myz}" />
+                </geometry>
+                <material name ="material_darkgray" />
+            </visual>
+            <collision>
+                <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${myx} ${myy} ${myz}" />
+                </geometry>
+            </collision>
+        </link>
+        <joint name="${jointname}" type="fixed">
+            <origin xyz="${x} ${y} ${z}" rpy="${roll} ${pitch} ${yaw}" />
+            <parent link="${parent}" />
+            <child link="${linkname}" />
+        </joint>   
+
+        <gazebo reference="${linkname}">
+            <sensor name="${name}" type="gpu_lidar">
+                <always_on>1</always_on>
+                <update_rate>5</update_rate>
+                <visualize>1</visualize>
+                <topic>${topic}_1</topic>
+                <ray>
+                    <scan>
+                        <horizontal>
+                            <samples>640</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-1.396263</min_angle>
+                            <max_angle>1.396263</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>0.08</min>
+                        <max>4</max>
+                        <resolution>0.02</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.1</mean>
+                        <stddev>0.005</stddev>
+                    </noise>
+                </ray>
+            </sensor>
+        </gazebo>     
+    </xacro:macro>
+</robot>

--- a/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
+++ b/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
@@ -33,7 +33,7 @@
                 <always_on>1</always_on>
                 <update_rate>5</update_rate>
                 <visualize>1</visualize>
-                <topic>${topic}_1</topic>
+                <topic>${topic}</topic>
                 <ray>
                     <scan>
                         <horizontal>

--- a/eddiebot_description/urdf/stacks/create_base.urdf.xacro
+++ b/eddiebot_description/urdf/stacks/create_base.urdf.xacro
@@ -3,6 +3,7 @@
 
   <xacro:include filename="$(find eddiebot_description)/urdf/common.urdf.xacro"/>
   <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ultrasonic_sensor.urdf.xacro"/>
+  <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ir_sensor.urdf.xacro"/>
 
   <!-- Define robot constants -->
   <xacro:property name="base_length" value="0.0095"/>
@@ -258,7 +259,11 @@
         <topic>model/eddiebot/joint_states</topic>
       </plugin>
     </gazebo>
-    <xacro:ultrasonic_sensor_sim topic="ultrasonic_1" name="ultrasonic_1" parent="base_link" linkname="ultrasonic_link1" jointname="ultrasonic_joint1" x="0.11" y="0.11" z="0.0275" roll="0" pitch="0" yaw="${M_PI/8}"/>
-    <xacro:ultrasonic_sensor_sim topic="ultrasonic_2" name="ultrasonic_2" parent="base_link" linkname="ultrasonic_link2" jointname="ultrasonic_joint2" x="0.11" y="-0.11" z="0.0275" roll="0" pitch="0" yaw="${-M_PI/8}"/>
+    <xacro:ultrasonic_sensor_sim topic="ultrasonic_1" name="ultrasonic_1" parent="base_link" linkname="ultrasonic_link1" jointname="ultrasonic_joint1" x="0.15" y="0.08" z="0.0275" roll="0" pitch="0" yaw="${M_PI/8}"/>
+    <xacro:ultrasonic_sensor_sim topic="ultrasonic_2" name="ultrasonic_2" parent="base_link" linkname="ultrasonic_link2" jointname="ultrasonic_joint2" x="0.15" y="-0.08" z="0.0275" roll="0" pitch="0" yaw="${-M_PI/8}"/>
+    
+    <xacro:ir_sensor_sim topic="ir_1" name="ir_sensor_1" parent="base_link" linkname="ir_link_1" jointname="ir_joint_1" x="0.12" y="0.15" z="0.0275" roll="0" pitch="0" yaw="0"/>
+    <xacro:ir_sensor_sim topic="ir_2" name="ir_sensor_2" parent="base_link" linkname="ir_link_2" jointname="ir_joint_2" x="0.12" y="-0.15" z="0.0275" roll="0" pitch="0" yaw="0"/>
+    <xacro:ir_sensor_sim topic="ir_3" name="ir_sensor_3" parent="base_link" linkname="ir_link_3" jointname="ir_joint_3" x="0.16" y="0.0" z="0.0275" roll="0" pitch="0" yaw="0"/>
   </xacro:macro>
 </robot>

--- a/eddiebot_description/urdf/stacks/create_base.urdf.xacro
+++ b/eddiebot_description/urdf/stacks/create_base.urdf.xacro
@@ -2,6 +2,7 @@
 <robot name="eddiebot_create_base" xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find eddiebot_description)/urdf/common.urdf.xacro"/>
+  <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ultrasonic_sensor.urdf.xacro"/>
 
   <!-- Define robot constants -->
   <xacro:property name="base_length" value="0.0095"/>
@@ -257,7 +258,7 @@
         <topic>model/eddiebot/joint_states</topic>
       </plugin>
     </gazebo>
-
+    <xacro:ultrasonic_sensor_sim topic="ultrasonic_1" name="ultrasonic_1" parent="base_link" linkname="ultrasonic_link1" jointname="ultrasonic_joint1" x="0.11" y="0.11" z="0.0275" roll="0" pitch="0" yaw="${M_PI/8}"/>
+    <xacro:ultrasonic_sensor_sim topic="ultrasonic_2" name="ultrasonic_2" parent="base_link" linkname="ultrasonic_link2" jointname="ultrasonic_joint2" x="0.11" y="-0.11" z="0.0275" roll="0" pitch="0" yaw="${-M_PI/8}"/>
   </xacro:macro>
-
 </robot>


### PR DESCRIPTION
Eddie has Five distance sensors (three infrared and two ultrasonic) on the front of its chassis that are for collision avoidance. Currently gazebo does not have a dedicated Ultrasonic or IR sensor (see [#19](https://github.com/gazebosim/gz-sensors/issues/19)). However, the behavior of these sensors can be estimated using LIDAR sensors. They have been implemented and appended to the robot's description.
The visual and collision of each sensor is a simple cuboid that roughly represents the shape of the sensor in real world.