### PR TITLE
Sara ghavampour add ultrasonic ir sensors

### DIFF
--- a/eddiebot_description/urdf/sensors/ir_sensor.urdf.xacro
+++ b/eddiebot_description/urdf/sensors/ir_sensor.urdf.xacro
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<robot name="ir_sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Microsoft Kinect for simulation -->
+    <xacro:macro name="ir_sensor" params="parent sensor_name topic_name jointname linkname x y z roll pitch yaw">
+        
+
+        <joint name="${jointname}" type="fixed">
+                <origin xyz="${x} ${y} ${z}" rpy="${roll} ${pitch} ${yaw}"/>
+                <parent link="${parent}"/>
+                <child link="${linkname}"/>
+        </joint>
+
+        <link name="${linkname}">
+            <visual>
+            <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+                <geometry>
+                <box size="0.03271 0.05794 0.033"/>
+                </geometry>
+            </visual>
+            <collision>
+                <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+                <geometry>
+                <box size="0.03271 0.05794 0.033"/>
+                </geometry>
+            </collision>
+            <inertial>
+                <mass value="0.1"/>
+                <origin xyz="0 0 0" />
+                <inertia ixx="0.003881243" ixy="0.0" ixz="0.0"
+                        iyy="0.000498940" iyz="0.0"
+                        izz="0.003879257" />
+            </inertial>
+        </link>
+
+        <gazebo reference="${linkname}">
+            <sensor name="${sensor_name}" type='gpu_lidar'>"
+                <always_on>1</always_on>
+                <update_rate>5</update_rate>
+                <visualize>1</visualize>
+                <topic>${topic_name}</topic>
+                <ray>
+                    <scan>
+                        <horizontal>
+                            <samples>1</samples>
+                            <resolution>1</resolution>
+                            <min_angle>0</min_angle>
+                            <max_angle>0</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>0.1</min>
+                        <max>0.8</max>
+                        <resolution>0.02</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.1</mean>
+                        <stddev>0.005</stddev>
+                    </noise>
+                </ray>
+            </sensor>
+        </gazebo>
+    </xacro:macro>
+</robot>

--- a/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
+++ b/eddiebot_description/urdf/sensors/ultrasonic_sensor.urdf.xacro
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<robot name="ultrasonic_sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- Microsoft Kinect for simulation -->
+    <xacro:macro name="ultrasonic_sensor" params="parent sensor_name topic_name jointname linkname x y z roll pitch yaw">
+        <!-- <gazebo>
+            <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
+                <render_engine>ogre2</render_engine>
+            </plugin>
+        </gazebo> -->
+
+        <joint name="${jointname}" type="fixed">
+                <origin xyz="${x} ${y} ${z}" rpy="${roll} ${pitch} ${yaw}"/>
+                <parent link="${parent}"/>
+                <child link="${linkname}"/>
+        </joint>
+
+        <link name="${linkname}">
+            <visual>
+            <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+                <geometry>
+                <box size="0.03271 0.05794 0.033"/>
+                </geometry>
+            </visual>
+            <collision>
+                <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+                <geometry>
+                <box size="0.03271 0.05794 0.033"/>
+                </geometry>
+            </collision>
+            <inertial>
+                <mass value="0.1"/>
+                <origin xyz="0 0 0" />
+                <inertia ixx="0.003881243" ixy="0.0" ixz="0.0"
+                        iyy="0.000498940" iyz="0.0"
+                        izz="0.003879257" />
+            </inertial>
+        </link>
+
+        <gazebo reference="${linkname}">
+            <sensor name="${sensor_name}" type='gpu_lidar'>"
+                <always_on>1</always_on>
+                <update_rate>5</update_rate>
+                <visualize>1</visualize>
+                <topic>${topic_name}</topic>
+                <ray>
+                    <scan>
+                        <horizontal>
+                            <samples>1</samples>
+                            <resolution>1</resolution>
+                            <min_angle>0</min_angle>
+                            <max_angle>0</max_angle>
+                        </horizontal>
+                    </scan>
+                    <range>
+                        <min>0.08</min>
+                        <max>4</max>
+                        <resolution>0.02</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0.1</mean>
+                        <stddev>0.005</stddev>
+                    </noise>
+                </ray>
+            </sensor>
+        </gazebo>
+    </xacro:macro>
+</robot>

--- a/eddiebot_description/urdf/stacks/create_base.urdf.xacro
+++ b/eddiebot_description/urdf/stacks/create_base.urdf.xacro
@@ -2,6 +2,8 @@
 <robot name="eddiebot_create_base" xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:include filename="$(find eddiebot_description)/urdf/common.urdf.xacro"/>
+  <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ultrasonic_sensor.urdf.xacro"/>
+  
 
   <!-- Define robot constants -->
   <xacro:property name="base_length" value="0.0095"/>
@@ -84,6 +86,7 @@
       <visual>
         <origin xyz="0 0 0" rpy="-${M_PI/2} 0 ${M_PI/2}" />
         <geometry>
+
           <mesh filename="package://eddiebot_description/meshes/28971-Caster-Wheel-Kit-v1.0.stl"/>
         </geometry>
         <material name ="material_lightgray">
@@ -257,7 +260,14 @@
         <topic>model/eddiebot/joint_states</topic>
       </plugin>
     </gazebo>
+  <!-- <xacro:ultrasonic_sensor params="base_link ultrasonic1 ultrasonic1_topic"/>
+  <xacro:ultrasonic_sensor params="base_link ultrasonic2 ultrasonic2_topic"/> -->
 
+  <!-- <xacro:ultrasonic_sensor parent="base_link" sensor_name="ultrasonic1" topic_name="ultrasonic1_topic" jointname="ultrasonic1_joint" linkname="ultrasonic1_link" x="0.18" y="0.1" z="0.02" roll="${M_PI/2}" pitch="0" yaw="${M_PI/2+M_PI/8}"/>
+  <xacro:ultrasonic_sensor parent="base_link" sensor_name="ultrasonic2" topic_name="ultrasonic2_topic" jointname="ultrasonic2_joint" linkname="ultrasonic2_link" x="0.18" y="-0.1" z="0.02" roll="${M_PI/2}" pitch="0" yaw="${M_PI/2-M_PI/8}"/> -->
+
+  <xacro:ultrasonic_sensor parent="base_link" sensor_name="ultrasonic1" topic_name="ultrasonic1_topic" jointname="ultrasonic1_joint" linkname="ultrasonic1_link" x="0.18" y="0.1" z="0.02" roll="0" pitch="0" yaw="${M_PI/7}"/>
+  <xacro:ultrasonic_sensor parent="base_link" sensor_name="ultrasonic2" topic_name="ultrasonic2_topic" jointname="ultrasonic2_joint" linkname="ultrasonic2_link" x="0.18" y="-0.1" z="0.02" roll="0" pitch="0" yaw="${-M_PI/7}"/>
   </xacro:macro>
 
 </robot>

--- a/eddiebot_description/urdf/stacks/create_base.urdf.xacro
+++ b/eddiebot_description/urdf/stacks/create_base.urdf.xacro
@@ -3,6 +3,7 @@
 
   <xacro:include filename="$(find eddiebot_description)/urdf/common.urdf.xacro"/>
   <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ultrasonic_sensor.urdf.xacro"/>
+  <xacro:include filename="$(find eddiebot_description)/urdf/sensors/ir_sensor.urdf.xacro"/>
   
 
   <!-- Define robot constants -->
@@ -268,6 +269,14 @@
 
   <xacro:ultrasonic_sensor parent="base_link" sensor_name="ultrasonic1" topic_name="ultrasonic1_topic" jointname="ultrasonic1_joint" linkname="ultrasonic1_link" x="0.18" y="0.1" z="0.02" roll="0" pitch="0" yaw="${M_PI/7}"/>
   <xacro:ultrasonic_sensor parent="base_link" sensor_name="ultrasonic2" topic_name="ultrasonic2_topic" jointname="ultrasonic2_joint" linkname="ultrasonic2_link" x="0.18" y="-0.1" z="0.02" roll="0" pitch="0" yaw="${-M_PI/7}"/>
+
+  <!-- IR sensors -->
+  <xacro:ir_sensor parent="base_link" sensor_name="ir_sensor1" topic_name="ir_sensor1_topic" jointname="ir_sensor1_joint" linkname="ir_sensor1_link" x="0.21" y="0" z="0.02" roll="0" pitch="0" yaw="0"/>
+  <xacro:ir_sensor parent="base_link" sensor_name="ir_sensor2" topic_name="ir_sensor2_topic" jointname="ir_sensor2_joint" linkname="ir_sensor2_link" x="0.1" y="0.18" z="0.02" roll="0" pitch="0" yaw="${M_PI/3}"/>
+  <xacro:ir_sensor parent="base_link" sensor_name="ir_sensor3" topic_name="ir_sensor3_topic" jointname="ir_sensor3_joint" linkname="ir_sensor3_link" x="0.1" y="-0.18" z="0.02" roll="0" pitch="0" yaw="${-M_PI/3}"/>
+
+
+
   </xacro:macro>
 
 </robot>

--- a/eddiebot_description/urdf/stacks/create_base.urdf.xacro
+++ b/eddiebot_description/urdf/stacks/create_base.urdf.xacro
@@ -273,7 +273,7 @@
   <!-- IR sensors -->
   <xacro:ir_sensor parent="base_link" sensor_name="ir_sensor1" topic_name="ir_sensor1_topic" jointname="ir_sensor1_joint" linkname="ir_sensor1_link" x="0.21" y="0" z="0.02" roll="0" pitch="0" yaw="0"/>
   <xacro:ir_sensor parent="base_link" sensor_name="ir_sensor2" topic_name="ir_sensor2_topic" jointname="ir_sensor2_joint" linkname="ir_sensor2_link" x="0.1" y="0.18" z="0.02" roll="0" pitch="0" yaw="${M_PI/3}"/>
-  <xacro:ir_sensor parent="base_link" sensor_name="ir_sensor3" topic_name="ir_sensor3_topic" jointname="ir_sensor3_joint" linkname="ir_sensor3_link" x="0.1" y="-0.18" z="0.02" roll="0" pitch="0" yaw="${-M_PI/3}"/>
+  <xacro:ir_sensor parent="base_link" sensor_name="ir_sensor3" topic_name="ir_sensor3_topic" jointname="ir_sensor3_joint" linkname="ir_sensor3_link" x="0.1" y="-0.18" z="0.02"  roll="0" pitch="0" yaw="${-M_PI/3}"/>
 
 
 


### PR DESCRIPTION
Adding ultrasonic and IR sensors to Eddie
These sensors(2 ultrasonic and 3 IR) are added to the base link. 
The steps to add these sensors are as follows:
1- Add a xarco file similar to existing sensors in urdf/sensors directory
2- Include the mentioned files in base xarco file
3- Trial and error is important to find the right numbers for position and orientation of sensors.
Remember that the name of corresponding links and joints should be identical; otherwise, accruing errors are inevitable. To do so, at the time of including sensors give the name of these as parameters.